### PR TITLE
Use errors.Is, update withdrawn dep, format cleanup

### DIFF
--- a/account_import.go
+++ b/account_import.go
@@ -2,6 +2,7 @@ package writefreely
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
@@ -128,11 +129,11 @@ func handleImport(app *App, u *User, w http.ResponseWriter, r *http.Request) err
 		}
 
 		post, err := wfimport.FromFile(filepath.Join(os.TempDir(), fname))
-		if err == wfimport.ErrEmptyFile {
+		if errors.Is(err, wfimport.ErrEmptyFile) {
 			// not a real error so don't log
 			_ = addSessionFlash(app, w, r, fmt.Sprintf("%s was empty, import skipped", formFile.Filename), nil)
 			continue
-		} else if err == wfimport.ErrInvalidContentType {
+		} else if errors.Is(err, wfimport.ErrInvalidContentType) {
 			// same as above
 			_ = addSessionFlash(app, w, r, fmt.Sprintf("%s is not a supported post file", formFile.Filename), nil)
 			continue

--- a/activitypub.go
+++ b/activitypub.go
@@ -16,6 +16,7 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -762,7 +763,7 @@ func getRemoteUser(app *App, actorID string) (*RemoteUser, error) {
 	var handle sql.NullString
 	err := app.db.QueryRow("SELECT id, inbox, shared_inbox, handle FROM remoteusers WHERE actor_id = ?", actorID).Scan(&u.ID, &u.Inbox, &u.SharedInbox, &handle)
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return nil, impart.HTTPError{http.StatusNotFound, "No remote user with that ID."}
 	case err != nil:
 		log.Error("Couldn't get remote user %s: %v", actorID, err)
@@ -780,7 +781,7 @@ func getRemoteUserFromHandle(app *App, handle string) (*RemoteUser, error) {
 	u := RemoteUser{Handle: handle}
 	err := app.db.QueryRow("SELECT id, actor_id, inbox, shared_inbox FROM remoteusers WHERE handle = ?", handle).Scan(&u.ID, &u.ActorID, &u.Inbox, &u.SharedInbox)
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return nil, ErrRemoteUserNotFound
 	case err != nil:
 		log.Error("Couldn't get remote user %s: %v", handle, err)

--- a/collections.go
+++ b/collections.go
@@ -13,6 +13,7 @@ package writefreely
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"html/template"
 	"math"
@@ -31,10 +32,11 @@ import (
 	"github.com/writeas/web-core/bots"
 	"github.com/writeas/web-core/log"
 	"github.com/writeas/web-core/posts"
+	"golang.org/x/net/idna"
+
 	"github.com/writefreely/writefreely/author"
 	"github.com/writefreely/writefreely/config"
 	"github.com/writefreely/writefreely/page"
-	"golang.org/x/net/idna"
 )
 
 type (
@@ -1172,7 +1174,7 @@ func handleWebCollectionUnlock(app *App, w http.ResponseWriter, r *http.Request)
 	var collHashedPass []byte
 	err := app.db.QueryRow("SELECT password FROM collectionpasswords INNER JOIN collections ON id = collection_id WHERE alias = ?", readReq.Alias).Scan(&collHashedPass)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			log.Error("No collectionpassword found when trying to read collection %s", readReq.Alias)
 			return impart.HTTPError{http.StatusInternalServerError, "Something went very wrong. The humans have been alerted."}
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/writefreely/writefreely
 
+go 1.19
+
 require (
-	git.mills.io/prologic/go-gopher v0.0.0-20210712135410-b7ebb55feece
 	github.com/clbanning/mxj v1.8.4 // indirect
 	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.15.0
@@ -17,7 +18,7 @@ require (
 	github.com/ikeikeikeike/go-sitemap-generator/v2 v2.0.2
 	github.com/kylemcc/twitter-text-go v0.0.0-20180726194232-7f582f6736ec
 	github.com/manifoldco/promptui v0.9.0
-	github.com/microcosm-cc/bluemonday v1.0.23
+	github.com/microcosm-cc/bluemonday v1.0.25
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d
 	github.com/stretchr/testify v1.8.4
@@ -38,9 +39,8 @@ require (
 	golang.org/x/crypto v0.13.0
 	golang.org/x/net v0.15.0
 	modernc.org/sqlite v1.20.0
-)
-
-require (
+	github.com/yuin/goldmark v1.5.6
+	go.abhg.dev/goldmark/hashtag v0.3.1
 	code.as/core/socks v1.0.0 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect
 	github.com/beevik/etree v1.1.0 // indirect
@@ -78,8 +78,6 @@ require (
 	github.com/writeas/go-writeas/v2 v2.0.2 // indirect
 	github.com/writeas/openssl-go v1.0.0 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect
-	github.com/yuin/goldmark v1.5.6 // indirect
-	go.abhg.dev/goldmark/hashtag v0.3.1 // indirect
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
@@ -96,5 +94,3 @@ require (
 	modernc.org/strutil v1.1.3 // indirect
 	modernc.org/token v1.0.1 // indirect
 )
-
-go 1.19

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,5 @@
 code.as/core/socks v1.0.0 h1:SPQXNp4SbEwjOAP9VzUahLHak8SDqy5n+9cm9tpjZOs=
 code.as/core/socks v1.0.0/go.mod h1:BAXBy5O9s2gmw6UxLqNJcVbWY7C/UPs+801CcSsfWOY=
-git.mills.io/prologic/go-gopher v0.0.0-20210712135410-b7ebb55feece h1:0esmnntqeuM1iBgHH0HOeSynsLA1l28p2K3h/WZuIfQ=
-git.mills.io/prologic/go-gopher v0.0.0-20210712135410-b7ebb55feece/go.mod h1:EMXlYOIbYJQhPTtIltgaaHtCYDawV/HL0dYf8ShzAck=
-github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/beevik/etree v1.1.0 h1:T0xke/WvNtMoCqgzPhkX2r4rjY3GDZFi+FjpRZY2Jbs=
@@ -95,8 +92,9 @@ github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/
 github.com/mattn/go-isatty v0.0.17 h1:BTarxUcIeDqL27Mc+vyvdWYSL28zpIhv3RoTdsLMPng=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-sqlite3 v1.14.15 h1:vfoHhTN1af61xCRSWzFIWzx2YskyMTwHLrExkBOjvxI=
-github.com/microcosm-cc/bluemonday v1.0.23 h1:SMZe2IGa0NuHvnVNAZ+6B38gsTbi5e4sViiWJyDDqFY=
 github.com/microcosm-cc/bluemonday v1.0.23/go.mod h1:mN70sk7UkkF8TUr2IGBpNN0jAgStuPzlK76QuruE/z4=
+github.com/microcosm-cc/bluemonday v1.0.25 h1:4NEwSfiJ+Wva0VxN5B8OwMicaJvD8r9tlJWm9rtloEg=
+github.com/microcosm-cc/bluemonday v1.0.25/go.mod h1:ZIOjCQp1OrzBBPIJmfX4qDYFuhU02nx4bn030ixfHLE=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
 github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d h1:VhgPp6v9qf9Agr/56bj7Y/xa04UccTW04VP0Qed4vnQ=
@@ -164,7 +162,6 @@ github.com/writefreely/go-nodeinfo v1.2.0 h1:La+YbTCvmpTwFhBSlebWDDL81N88Qf/SCAv
 github.com/writefreely/go-nodeinfo v1.2.0/go.mod h1:UTvE78KpcjYOlRHupZIiSEFcXHioTXuacCbHU+CAcPg=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673/go.mod h1:N3UwUGtsrSj3ccvlPHLoLsHnpR27oXr4ZE984MbSER8=
-github.com/yuin/goldmark v1.4.13 h1:fVcFKWvrslecOb/tg+Cc05dkeYx540o0FuFt3nUVDoE=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.5.6 h1:COmQAWTCcGetChm3Ig7G/t8AFAN00t+o8Mt4cf7JpwA=
 github.com/yuin/goldmark v1.5.6/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/unregisteredusers.go
+++ b/unregisteredusers.go
@@ -13,6 +13,7 @@ package writefreely
 import (
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/writeas/impart"
@@ -105,7 +106,7 @@ func handleUsernameCheck(app *App, w http.ResponseWriter, r *http.Request) error
 	var un string
 	err := app.db.QueryRow("SELECT username FROM users WHERE username = ?", finalUsername).Scan(&un)
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return impart.WriteSuccess(w, finalUsername, http.StatusOK)
 	case err != nil:
 		log.Error("Couldn't SELECT username: %v", err)
@@ -136,7 +137,7 @@ func getValidUsername(app *App, reqName, prevName string) (string, *impart.HTTPE
 	var un string
 	err := app.db.QueryRow("SELECT username FROM users WHERE username = ?", finalUsername).Scan(&un)
 	switch {
-	case err == sql.ErrNoRows:
+	case errors.Is(err, sql.ErrNoRows):
 		return finalUsername, nil
 	case err != nil:
 		log.Error("Couldn't SELECT username: %v", err)


### PR DESCRIPTION
- Update old code to use `errors.Is` for error comparisons.
- Upgrade bluemonday from a withdrawn version to the current version.
- Clean up `go.mod` to put the Go version at the top and avoid unnecessary split dependency lists.
- For touched files, group imports into 3 groups: stdlib, current project, and other.