### PR TITLE
improved the error message for when the config file has not been crea…

### DIFF
--- a/app.go
+++ b/app.go
@@ -14,8 +14,10 @@ import (
 	"crypto/tls"
 	"database/sql"
 	_ "embed"
+	"errors"
 	"fmt"
 	"html/template"
+	"io/fs"
 	"net"
 	"net/http"
 	"net/url"
@@ -46,6 +48,8 @@ import (
 )
 
 const (
+	assumedExecutableName = "postfreely" // Only use this if os.Executable() doesn't work.
+
 	staticDir       = "static"
 	assumedTitleLen = 80
 	postsPerPage    = 10
@@ -146,6 +150,14 @@ func (app *App) LoadConfig() error {
 	cfg, err := config.Load(app.cfgFile)
 	if err != nil {
 		log.Error("Unable to load configuration: %v", err)
+		if errors.Is(err, fs.ErrNotExist) {
+			log.Error("Have you created the config file yet? If not, run —")
+			var cmdname string = assumedExecutableName
+			if s, err := os.Executable(); nil == err {
+				cmdname = s
+			}
+			log.Error("\t%s config start", cmdname)
+		}
 		os.Exit(1)
 		return err
 	}


### PR DESCRIPTION
Building and running `postfreely` successful can be difficult to do currently.

The `postfreely` program will return an error message until a config file is created.

However, the error message does _not_ give any hints on how to resolve this problem.

This pull request add a helpful hint on how to create a config file, by running `postfreely` with the "config start" command.