### PR TITLE
improved the error message for when the keys have not been generated yet

### DIFF
--- a/app.go
+++ b/app.go
@@ -407,7 +407,7 @@ func Initialize(apper Apper, debug bool) (*App, error) {
 	initKeyPaths(apper.App()) // TODO: find a better way to do this, since it's unneeded in all Apper implementations
 	err = InitKeys(apper)
 	if err != nil {
-		return nil, fmt.Errorf("init keys: %s", err)
+		return nil, fmt.Errorf("init keys: %w", err)
 	}
 	apper.App().InitUpdates()
 

--- a/cmd/writefreely/main.go
+++ b/cmd/writefreely/main.go
@@ -11,7 +11,9 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 
@@ -19,6 +21,10 @@ import (
 	"github.com/urfave/cli/v2"
 	"github.com/writeas/web-core/log"
 	"github.com/writefreely/writefreely"
+)
+
+const (
+	assumedExecutableName = "postfreely" // Only use this if os.Executable() doesn't work.
 )
 
 func main() {
@@ -118,6 +124,14 @@ func main() {
 	err := app.Run(os.Args)
 	if err != nil {
 		log.Error(err.Error())
+		if errors.Is(err, fs.ErrNotExist) {
+			log.Error("Have you generated the keys yet? If not, run —")
+			var cmdname string = assumedExecutableName
+			if s, err := os.Executable(); nil == err {
+				cmdname = s
+			}
+			log.Error("\t%s keys generate", cmdname)
+		}
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Building and running `postfreely` successful can be difficult to do currently.

The `postfreely` program will return an error message until the keys are generated.

However, the error message does not give any hints on how to resolve this problem.

This pull request adds a helpful hint on how to generate the keys, by running postfreely with the "keys generate" command.