### PR TITLE
consolidated the database-type constants

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,8 @@ import (
 	"github.com/yuin/goldmark"
 	"github.com/yuin/goldmark/extension"
 	"golang.org/x/net/idna"
+
+	"github.com/writefreely/writefreely/db"
 )
 
 const (
@@ -217,7 +219,7 @@ func New() *Config {
 
 // UseMySQL resets the Config's Database to use default values for a MySQL setup.
 func (cfg *Config) UseMySQL(fresh bool) {
-	cfg.Database.Type = "mysql"
+	cfg.Database.Type = db.TypeMySQL
 	if fresh {
 		cfg.Database.Host = "localhost"
 		cfg.Database.Port = 3306
@@ -226,7 +228,7 @@ func (cfg *Config) UseMySQL(fresh bool) {
 
 // UseSQLite resets the Config's Database to use default values for a SQLite setup.
 func (cfg *Config) UseSQLite(fresh bool) {
-	cfg.Database.Type = "sqlite3"
+	cfg.Database.Type = db.TypeSQLite
 	if fresh {
 		cfg.Database.FileName = "writefreely.db"
 	}

--- a/database-sqlite.go
+++ b/database-sqlite.go
@@ -22,6 +22,8 @@ import (
 	"github.com/writeas/web-core/log"
 	"modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
+
+	dbase "github.com/writefreely/writefreely/db"
 )
 
 func init() {
@@ -45,11 +47,11 @@ func init() {
 }
 
 func (db *datastore) isDuplicateKeyErr(err error) bool {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		if err, ok := err.(*sqlite.Error); ok {
 			return err.Code() == sqlite3.SQLITE_CONSTRAINT
 		}
-	} else if db.driverName == driverMySQL {
+	} else if db.driverName == dbase.TypeMySQL {
 		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
 			return mysqlErr.Number == mySQLErrDuplicateKey
 		}
@@ -61,7 +63,7 @@ func (db *datastore) isDuplicateKeyErr(err error) bool {
 }
 
 func (db *datastore) isIgnorableError(err error) bool {
-	if db.driverName == driverMySQL {
+	if db.driverName == dbase.TypeMySQL {
 		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
 			return mysqlErr.Number == mySQLErrCollationMix
 		}
@@ -73,7 +75,7 @@ func (db *datastore) isIgnorableError(err error) bool {
 }
 
 func (db *datastore) isHighLoadError(err error) bool {
-	if db.driverName == driverMySQL {
+	if db.driverName == dbase.TypeMySQL {
 		if mysqlErr, ok := err.(*mysql.MySQLError); ok {
 			return mysqlErr.Number == mySQLErrMaxUserConns || mysqlErr.Number == mySQLErrTooManyConns
 		}

--- a/database.go
+++ b/database.go
@@ -36,6 +36,7 @@ import (
 	"github.com/writeas/web-core/query"
 
 	"github.com/writefreely/writefreely/author"
+	dbase "github.com/writefreely/writefreely/db"
 	"github.com/writefreely/writefreely/config"
 	"github.com/writefreely/writefreely/key"
 )
@@ -45,9 +46,6 @@ const (
 	mySQLErrCollationMix = 1267
 	mySQLErrTooManyConns = 1040
 	mySQLErrMaxUserConns = 1203
-
-	driverMySQL  = "mysql"
-	driverSQLite = "sqlite3"
 )
 
 var (
@@ -152,21 +150,21 @@ type datastore struct {
 var _ writestore = &datastore{}
 
 func (db *datastore) now() string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return "strftime('%Y-%m-%d %H:%M:%S','now')"
 	}
 	return "NOW()"
 }
 
 func (db *datastore) clip(field string, l int) string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return fmt.Sprintf("SUBSTR(%s, 0, %d)", field, l)
 	}
 	return fmt.Sprintf("LEFT(%s, %d)", field, l)
 }
 
 func (db *datastore) upsert(indexedCols ...string) string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		// NOTE: SQLite UPSERT syntax only works in v3.24.0 (2018-06-04) or later
 		// Leaving this for whenever we can upgrade and include it in our binary
 		cc := strings.Join(indexedCols, ", ")
@@ -176,7 +174,7 @@ func (db *datastore) upsert(indexedCols ...string) string {
 }
 
 func (db *datastore) dateSub(l int, unit string) string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return fmt.Sprintf("DATETIME('now', '-%d %s')", l, unit)
 	}
 	return fmt.Sprintf("DATE_SUB(NOW(), INTERVAL %d %s)", l, unit)
@@ -661,7 +659,7 @@ func (db *datastore) CreatePost(userID, collID int64, post *SubmittedPost) (*Pos
 	}
 
 	created := time.Now()
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		// SQLite stores datetimes in UTC, so convert time.Now() to it here
 		created = created.UTC()
 	}
@@ -670,7 +668,7 @@ func (db *datastore) CreatePost(userID, collID int64, post *SubmittedPost) (*Pos
 		if err != nil {
 			log.Error("Unable to parse Created time '%s': %v", *post.Created, err)
 			created = time.Now()
-			if db.driverName == driverSQLite {
+			if db.driverName == dbase.TypeSQLite {
 				// SQLite stores datetimes in UTC, so convert time.Now() to it here
 				created = created.UTC()
 			}
@@ -896,7 +894,7 @@ func (db *datastore) UpdateCollection(c *SubmittedCollection, alias string) erro
 
 	// Update MathJax value
 	if c.MathJax {
-		if db.driverName == driverSQLite {
+		if db.driverName == dbase.TypeSQLite {
 			_, err = db.Exec("INSERT OR REPLACE INTO collectionattributes (collection_id, attribute, value) VALUES (?, ?, ?)", collID, "render_mathjax", "1")
 		} else {
 			_, err = db.Exec("INSERT INTO collectionattributes (collection_id, attribute, value) VALUES (?, ?, ?) "+db.upsert("collection_id", "attribute")+" value = ?", collID, "render_mathjax", "1", "1")
@@ -967,7 +965,7 @@ func (db *datastore) UpdateCollection(c *SubmittedCollection, alias string) erro
 			log.Error("Unable to create hash: %s", err)
 			return impart.HTTPError{http.StatusInternalServerError, "Could not create password hash."}
 		}
-		if db.driverName == driverSQLite {
+		if db.driverName == dbase.TypeSQLite {
 			_, err = db.Exec("INSERT OR REPLACE INTO collectionpasswords (collection_id, password) VALUES ((SELECT id FROM collections WHERE alias = ?), ?)", alias, hashedPass)
 		} else {
 			_, err = db.Exec("INSERT INTO collectionpasswords (collection_id, password) VALUES ((SELECT id FROM collections WHERE alias = ?), ?) "+db.upsert("collection_id")+" password = ?", alias, hashedPass, hashedPass)
@@ -1230,7 +1228,7 @@ func (db *datastore) GetPostsTagged(cfg *config.Config, c *Collection, tag strin
 
 	var rows *sql.Rows
 	var err error
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) regexp ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, `.*#`+strings.ToLower(tag)+`\b.*`)
 	} else {
 		rows, err = db.Query("SELECT "+postCols+" FROM posts WHERE collection_id = ? AND LOWER(content) RLIKE ? "+timeCondition+" ORDER BY created "+order+limitStr, collID, "#"+strings.ToLower(tag)+"[[:>:]]")
@@ -2549,7 +2547,7 @@ func (db *datastore) GetDynamicContent(id string) (*instanceContent, error) {
 
 func (db *datastore) UpdateDynamicContent(id, title, content, contentType string) error {
 	var err error
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		_, err = db.Exec("INSERT OR REPLACE INTO appcontent (id, title, content, updated, content_type) VALUES (?, ?, ?, "+db.now()+", ?)", id, title, content, contentType)
 	} else {
 		_, err = db.Exec("INSERT INTO appcontent (id, title, content, updated, content_type) VALUES (?, ?, ?, "+db.now()+", ?) "+db.upsert("id")+" title = ?, content = ?, updated = "+db.now(), id, title, content, contentType, title, content)
@@ -2680,7 +2678,7 @@ func (db *datastore) ValidateOAuthState(ctx context.Context, state string) (stri
 
 func (db *datastore) RecordRemoteUserID(ctx context.Context, localUserID int64, remoteUserID, provider, clientID, accessToken string) error {
 	var err error
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		_, err = db.ExecContext(ctx, "INSERT OR REPLACE INTO oauth_users (user_id, remote_user_id, provider, client_id, access_token) VALUES (?, ?, ?, ?, ?)", localUserID, remoteUserID, provider, clientID, accessToken)
 	} else {
 		_, err = db.ExecContext(ctx, "INSERT INTO oauth_users (user_id, remote_user_id, provider, client_id, access_token) VALUES (?, ?, ?, ?, ?) "+db.upsert("user")+" access_token = ?", localUserID, remoteUserID, provider, clientID, accessToken, accessToken)
@@ -2739,7 +2737,7 @@ func (db *datastore) GetOauthAccounts(ctx context.Context, userID int64) ([]oaut
 func (db *datastore) DatabaseInitialized() bool {
 	var dummy string
 	var err error
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		err = db.QueryRow("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'users'").Scan(&dummy)
 	} else {
 		err = db.QueryRow("SHOW TABLES LIKE 'users'").Scan(&dummy)

--- a/db/types.go
+++ b/db/types.go
@@ -1,0 +1,6 @@
+package db
+
+const (
+        TypeMySQL  = "mysql"
+        TypeSQLite = "sqlite3"
+)

--- a/migrations/drivers.go
+++ b/migrations/drivers.go
@@ -12,25 +12,27 @@ package migrations
 
 import (
 	"fmt"
+
+	dbase "github.com/writefreely/writefreely/db"
 )
 
 // TODO: use now() from writefreely pkg
 func (db *datastore) now() string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return "strftime('%Y-%m-%d %H:%M:%S','now')"
 	}
 	return "NOW()"
 }
 
 func (db *datastore) typeInt() string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return "INTEGER"
 	}
 	return "INT"
 }
 
 func (db *datastore) typeSmallInt() string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return "INTEGER"
 	}
 	return "SMALLINT"
@@ -41,21 +43,21 @@ func (db *datastore) typeText() string {
 }
 
 func (db *datastore) typeChar(l int) string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return "TEXT"
 	}
 	return fmt.Sprintf("CHAR(%d)", l)
 }
 
 func (db *datastore) typeVarChar(l int) string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return "TEXT"
 	}
 	return fmt.Sprintf("VARCHAR(%d)", l)
 }
 
 func (db *datastore) typeBool() string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return "INTEGER"
 	}
 	return "TINYINT(1)"
@@ -66,21 +68,21 @@ func (db *datastore) typeDateTime() string {
 }
 
 func (db *datastore) collateMultiByte() string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return ""
 	}
 	return " COLLATE utf8_bin"
 }
 
 func (db *datastore) engine() string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return ""
 	}
 	return " ENGINE = InnoDB"
 }
 
 func (db *datastore) after(colName string) string {
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		return ""
 	}
 	return " AFTER " + colName

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -15,6 +15,8 @@ import (
 	"database/sql"
 
 	"github.com/writeas/web-core/log"
+
+	dbase "github.com/writefreely/writefreely/db"
 )
 
 // TODO: refactor to use the datastore struct from writefreely pkg
@@ -26,12 +28,6 @@ type datastore struct {
 func NewDatastore(db *sql.DB, dn string) *datastore {
 	return &datastore{db, dn}
 }
-
-// TODO: use these consts from writefreely pkg
-const (
-	driverMySQL  = "mysql"
-	driverSQLite = "sqlite3"
-)
 
 type Migration interface {
 	Description() string
@@ -129,7 +125,7 @@ func Migrate(db *datastore) error {
 func (db *datastore) tableExists(t string) bool {
 	var dummy string
 	var err error
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		err = db.QueryRow("SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?", t).Scan(&dummy)
 	} else {
 		err = db.QueryRow("SHOW TABLES LIKE '" + t + "'").Scan(&dummy)

--- a/migrations/v11.go
+++ b/migrations/v11.go
@@ -10,11 +10,15 @@
 
 package migrations
 
+import (
+	dbase "github.com/writefreely/writefreely/db"
+)
+
 /**
  * Widen `oauth_users.access_token`, necessary only for mysql
  */
 func widenOauthAcceesToken(db *datastore) error {
-	if db.driverName == driverMySQL {
+	if db.driverName == dbase.TypeMySQL {
 		t, err := db.Begin()
 		if err != nil {
 			t.Rollback()

--- a/migrations/v4.go
+++ b/migrations/v4.go
@@ -14,20 +14,20 @@ import (
 	"context"
 	"database/sql"
 
-	wf_db "github.com/writefreely/writefreely/db"
+	dbase "github.com/writefreely/writefreely/db"
 )
 
 func oauth(db *datastore) error {
-	dialect := wf_db.DialectMySQL
-	if db.driverName == driverSQLite {
-		dialect = wf_db.DialectSQLite
+	dialect := dbase.DialectMySQL
+	if db.driverName == dbase.TypeSQLite {
+		dialect = dbase.DialectSQLite
 	}
-	return wf_db.RunTransactionWithOptions(context.Background(), db.DB, &sql.TxOptions{}, func(ctx context.Context, tx *sql.Tx) error {
+	return dbase.RunTransactionWithOptions(context.Background(), db.DB, &sql.TxOptions{}, func(ctx context.Context, tx *sql.Tx) error {
 		createTableUsersOauth, err := dialect.
 			Table("oauth_users").
 			SetIfNotExists(false).
-			Column(dialect.Column("user_id", wf_db.ColumnTypeInteger, wf_db.UnsetSize)).
-			Column(dialect.Column("remote_user_id", wf_db.ColumnTypeInteger, wf_db.UnsetSize)).
+			Column(dialect.Column("user_id", dbase.ColumnTypeInteger, dbase.UnsetSize)).
+			Column(dialect.Column("remote_user_id", dbase.ColumnTypeInteger, dbase.UnsetSize)).
 			ToSQL()
 		if err != nil {
 			return err
@@ -35,9 +35,9 @@ func oauth(db *datastore) error {
 		createTableOauthClientState, err := dialect.
 			Table("oauth_client_states").
 			SetIfNotExists(false).
-			Column(dialect.Column("state", wf_db.ColumnTypeVarChar, wf_db.OptionalInt{Set: true, Value: 255})).
-			Column(dialect.Column("used", wf_db.ColumnTypeBool, wf_db.UnsetSize)).
-			Column(dialect.Column("created_at", wf_db.ColumnTypeDateTime, wf_db.UnsetSize).SetDefaultCurrentTimestamp()).
+			Column(dialect.Column("state", dbase.ColumnTypeVarChar, dbase.OptionalInt{Set: true, Value: 255})).
+			Column(dialect.Column("used", dbase.ColumnTypeBool, dbase.UnsetSize)).
+			Column(dialect.Column("created_at", dbase.ColumnTypeDateTime, dbase.UnsetSize).SetDefaultCurrentTimestamp()).
 			UniqueConstraint("state").
 			ToSQL()
 		if err != nil {

--- a/migrations/v5.go
+++ b/migrations/v5.go
@@ -14,55 +14,55 @@ import (
 	"context"
 	"database/sql"
 
-	wf_db "github.com/writefreely/writefreely/db"
+	dbase "github.com/writefreely/writefreely/db"
 )
 
 func oauthSlack(db *datastore) error {
-	dialect := wf_db.DialectMySQL
-	if db.driverName == driverSQLite {
-		dialect = wf_db.DialectSQLite
+	dialect := dbase.DialectMySQL
+	if db.driverName == dbase.TypeSQLite {
+		dialect = dbase.DialectSQLite
 	}
-	return wf_db.RunTransactionWithOptions(context.Background(), db.DB, &sql.TxOptions{}, func(ctx context.Context, tx *sql.Tx) error {
-		builders := []wf_db.SQLBuilder{
+	return dbase.RunTransactionWithOptions(context.Background(), db.DB, &sql.TxOptions{}, func(ctx context.Context, tx *sql.Tx) error {
+		builders := []dbase.SQLBuilder{
 			dialect.
 				AlterTable("oauth_client_states").
 				AddColumn(dialect.
 					Column(
 						"provider",
-						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 24}).SetDefault("")),
+						dbase.ColumnTypeVarChar,
+						dbase.OptionalInt{Set: true, Value: 24}).SetDefault("")),
 			dialect.
 				AlterTable("oauth_client_states").
 				AddColumn(dialect.
 					Column(
 						"client_id",
-						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 128}).SetDefault("")),
+						dbase.ColumnTypeVarChar,
+						dbase.OptionalInt{Set: true, Value: 128}).SetDefault("")),
 			dialect.
 				AlterTable("oauth_users").
 				AddColumn(dialect.
 					Column(
 						"provider",
-						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 24}).SetDefault("")),
+						dbase.ColumnTypeVarChar,
+						dbase.OptionalInt{Set: true, Value: 24}).SetDefault("")),
 			dialect.
 				AlterTable("oauth_users").
 				AddColumn(dialect.
 					Column(
 						"client_id",
-						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 128}).SetDefault("")),
+						dbase.ColumnTypeVarChar,
+						dbase.OptionalInt{Set: true, Value: 128}).SetDefault("")),
 			dialect.
 				AlterTable("oauth_users").
 				AddColumn(dialect.
 					Column(
 						"access_token",
-						wf_db.ColumnTypeVarChar,
-						wf_db.OptionalInt{Set: true, Value: 512}).SetDefault("")),
+						dbase.ColumnTypeVarChar,
+						dbase.OptionalInt{Set: true, Value: 512}).SetDefault("")),
 			dialect.CreateUniqueIndex("oauth_users_uk", "oauth_users", "user_id", "provider", "client_id"),
 		}
 
-		if dialect != wf_db.DialectSQLite {
+		if dialect != dbase.DialectSQLite {
 			// This updates the length of the `remote_user_id` column. It isn't needed for SQLite databases.
 			builders = append(builders, dialect.
 				AlterTable("oauth_users").
@@ -70,8 +70,8 @@ func oauthSlack(db *datastore) error {
 					dialect.
 						Column(
 							"remote_user_id",
-							wf_db.ColumnTypeVarChar,
-							wf_db.OptionalInt{Set: true, Value: 128})))
+							dbase.ColumnTypeVarChar,
+							dbase.OptionalInt{Set: true, Value: 128})))
 		}
 
 		for _, builder := range builders {

--- a/migrations/v7.go
+++ b/migrations/v7.go
@@ -14,23 +14,23 @@ import (
 	"context"
 	"database/sql"
 
-	wf_db "github.com/writefreely/writefreely/db"
+	dbase "github.com/writefreely/writefreely/db"
 )
 
 func oauthAttach(db *datastore) error {
-	dialect := wf_db.DialectMySQL
-	if db.driverName == driverSQLite {
-		dialect = wf_db.DialectSQLite
+	dialect := dbase.DialectMySQL
+	if db.driverName == dbase.TypeSQLite {
+		dialect = dbase.DialectSQLite
 	}
-	return wf_db.RunTransactionWithOptions(context.Background(), db.DB, &sql.TxOptions{}, func(ctx context.Context, tx *sql.Tx) error {
-		builders := []wf_db.SQLBuilder{
+	return dbase.RunTransactionWithOptions(context.Background(), db.DB, &sql.TxOptions{}, func(ctx context.Context, tx *sql.Tx) error {
+		builders := []dbase.SQLBuilder{
 			dialect.
 				AlterTable("oauth_client_states").
 				AddColumn(dialect.
 					Column(
 						"attach_user_id",
-						wf_db.ColumnTypeInteger,
-						wf_db.OptionalInt{Set: true, Value: 24}).SetNullable(true)),
+						dbase.ColumnTypeInteger,
+						dbase.OptionalInt{Set: true, Value: 24}).SetNullable(true)),
 		}
 		for _, builder := range builders {
 			query, err := builder.ToSQL()

--- a/migrations/v8.go
+++ b/migrations/v8.go
@@ -14,19 +14,19 @@ import (
 	"context"
 	"database/sql"
 
-	wf_db "github.com/writefreely/writefreely/db"
+	dbase "github.com/writefreely/writefreely/db"
 )
 
 func oauthInvites(db *datastore) error {
-	dialect := wf_db.DialectMySQL
-	if db.driverName == driverSQLite {
-		dialect = wf_db.DialectSQLite
+	dialect := dbase.DialectMySQL
+	if db.driverName == dbase.TypeSQLite {
+		dialect = dbase.DialectSQLite
 	}
-	return wf_db.RunTransactionWithOptions(context.Background(), db.DB, &sql.TxOptions{}, func(ctx context.Context, tx *sql.Tx) error {
-		builders := []wf_db.SQLBuilder{
+	return dbase.RunTransactionWithOptions(context.Background(), db.DB, &sql.TxOptions{}, func(ctx context.Context, tx *sql.Tx) error {
+		builders := []dbase.SQLBuilder{
 			dialect.
 				AlterTable("oauth_client_states").
-				AddColumn(dialect.Column("invite_code", wf_db.ColumnTypeChar, wf_db.OptionalInt{
+				AddColumn(dialect.Column("invite_code", dbase.ColumnTypeChar, dbase.OptionalInt{
 					Set:   true,
 					Value: 6,
 				}).SetNullable(true)),

--- a/migrations/v9.go
+++ b/migrations/v9.go
@@ -10,6 +10,10 @@
 
 package migrations
 
+import (
+	dbase "github.com/writefreely/writefreely/db"
+)
+
 func optimizeDrafts(db *datastore) error {
 	t, err := db.Begin()
 	if err != nil {
@@ -17,7 +21,7 @@ func optimizeDrafts(db *datastore) error {
 		return err
 	}
 
-	if db.driverName == driverSQLite {
+	if db.driverName == dbase.TypeSQLite {
 		_, err = t.Exec(`CREATE INDEX key_owner_post_id ON posts (owner_id, id)`)
 	} else {
 		_, err = t.Exec(`ALTER TABLE posts ADD INDEX(owner_id, id)`)


### PR DESCRIPTION
There were multiple database-type constants laying around, to represent the values:

* `sqlite3`
* `mysql`

Consolidated them in the (pre-existing) `db` package.

So, now we have:

* `db.TypeSQLite`
* `db.TypeMySQL`

And am now using that throughout the code, where it is needed.

There was even a TO-DO for it.

I TO-DONE it 🙂