### PR TITLE
cleaned up some of the gopher related code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY --from=build --chown=daemon:daemon /stage /go
 WORKDIR /go
 VOLUME /go/keys
 EXPOSE 8080
+EXPOSE 7007
 USER daemon
 
 ENTRYPOINT ["cmd/writefreely/writefreely"]

--- a/app.go
+++ b/app.go
@@ -536,7 +536,7 @@ requests. We recommend supplying a valid host name.`)
 				os.Exit(1)
 			}
 		} else {
-			bindAddress = fmt.Sprintf("%s:%d", bindAddress, app.cfg.Server.Port)
+			bindAddress = fmt.Sprintf("%s:%d", bindAddress, app.cfg.Server.WWWPort)
 		}
 
 		log.Info("Serving on %s://%s", protocol, bindAddress)

--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ type (
 	// ServerCfg holds values that affect how the HTTP server runs
 	ServerCfg struct {
 		HiddenHost string `ini:"hidden_host"`
-		Port       int    `ini:"port"`
+		WWWPort    int    `ini:"port"`
 		Bind       string `ini:"bind"`
 
 		TLSCertPath string `ini:"tls_cert_path"`
@@ -197,8 +197,9 @@ type (
 func New() *Config {
 	c := &Config{
 		Server: ServerCfg{
-			Port: 8080,
+			WWWPort: 8080,
 			Bind: "localhost", /* IPV6 support when not using localhost? */
+			GopherPort: 7007,
 		},
 		App: AppCfg{
 			Host:           "http://localhost:8080",
@@ -235,7 +236,7 @@ func (cfg *Config) UseSQLite(fresh bool) {
 // IsSecureStandalone returns whether or not the application is running as a
 // standalone server with TLS enabled.
 func (cfg *Config) IsSecureStandalone() bool {
-	return cfg.Server.Port == 443 && cfg.Server.TLSCertPath != "" && cfg.Server.TLSKeyPath != ""
+	return cfg.Server.WWWPort == 443 && cfg.Server.TLSCertPath != "" && cfg.Server.TLSKeyPath != ""
 }
 
 func (ac *AppCfg) LandingPath() string {

--- a/config/setup.go
+++ b/config/setup.go
@@ -86,15 +86,30 @@ func Configure(fname string, configSections string) (*SetupData, error) {
 			// Running in dev environment or behind reverse proxy; ask for port
 			prompt = promptui.Prompt{
 				Templates: tmpls,
-				Label:     "Local port",
+				Label:     "Local HTTP port",
 				Validate:  validatePort,
-				Default:   fmt.Sprintf("%d", data.Config.Server.Port),
+				Default:   fmt.Sprintf("%d", data.Config.Server.WWWPort),
 			}
 			port, err := prompt.Run()
 			if err != nil {
 				return data, err
 			}
-			data.Config.Server.Port, _ = strconv.Atoi(port) // Ignore error, as we've already validated number
+			data.Config.Server.WWWPort, _ = strconv.Atoi(port) // Ignore error, as we've already validated number
+		}
+
+		if isDevEnv || !isStandalone {
+			// Running in dev environment or behind reverse proxy; ask for port
+			prompt = promptui.Prompt{
+				Templates: tmpls,
+				Label:     "Local Gopher port",
+				Validate:  validatePort,
+				Default:   fmt.Sprintf("%d", data.Config.Server.GopherPort),
+			}
+			port, err := prompt.Run()
+			if err != nil {
+				return data, err
+			}
+			data.Config.Server.GopherPort, _ = strconv.Atoi(port) // Ignore error, as we've already validated number
 		}
 
 		if isStandalone {
@@ -109,11 +124,11 @@ func Configure(fname string, configSections string) (*SetupData, error) {
 			}
 			if sel == 0 {
 				data.Config.Server.Autocert = false
-				data.Config.Server.Port = 80
+				data.Config.Server.WWWPort = 80
 				data.Config.Server.TLSCertPath = ""
 				data.Config.Server.TLSKeyPath = ""
 			} else if sel == 1 || sel == 2 {
-				data.Config.Server.Port = 443
+				data.Config.Server.WWWPort = 443
 				data.Config.Server.Autocert = sel == 2
 
 				if sel == 1 {
@@ -309,7 +324,7 @@ func Configure(fname string, configSections string) (*SetupData, error) {
 
 		prompt = promptui.Prompt{
 			Templates: tmpls,
-			Label:     "Public URL",
+			Label:     "Public HTTP URL",
 			Validate:  validateDomain,
 			Default:   data.Config.App.Host,
 		}


### PR DESCRIPTION
Cleaned up some of the gopher-protocol related code.

Just like code uses the unprivileged TCP port 8080 for WWW — using the unprivileged TCP port 7007 for Gopher.