### PR TITLE
Embed templates in binary, add command to unpack

### DIFF
--- a/app.go
+++ b/app.go
@@ -414,6 +414,12 @@ func Initialize(apper Apper, debug bool) (*App, error) {
 	// Load templates
 	err := InitTemplates(apper.App().Config())
 	if err != nil {
+		log.Error("Have you unpacked the template files? If not, run —")
+		cmdname := assumedExecutableName
+		if s, err := os.Executable(); nil == err {
+			cmdname = s
+		}
+		log.Error("\t%s templates generate", cmdname)
 		return nil, fmt.Errorf("load templates: %w", err)
 	}
 

--- a/cmd/postfreely/main.go
+++ b/cmd/postfreely/main.go
@@ -17,9 +17,10 @@ import (
 	"os"
 
 	"github.com/gorilla/mux"
-	"github.com/postfreely/postfreely"
 	"github.com/urfave/cli/v2"
 	"github.com/writeas/web-core/log"
+
+	"github.com/postfreely/postfreely"
 )
 
 const (
@@ -116,6 +117,7 @@ func main() {
 		&cmdUser,
 		&cmdDB,
 		&cmdConfig,
+		&cmdTemplates,
 		&cmdKeys,
 		&cmdServe,
 	}

--- a/cmd/postfreely/templates.go
+++ b/cmd/postfreely/templates.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"github.com/urfave/cli/v2"
+
+	"github.com/postfreely/postfreely"
+)
+
+var (
+	cmdTemplates cli.Command = cli.Command{
+		Name:  "templates",
+		Usage: "template management tools",
+		Subcommands: []*cli.Command{
+			&cmdTemplatesGenerate,
+		},
+	}
+
+	cmdTemplatesGenerate cli.Command = cli.Command{
+		Name:    "generate",
+		Aliases: []string{"gen"},
+		Usage:   "Generate an initial set of templates",
+		Action:  genTemplatesAction,
+	}
+)
+
+func genTemplatesAction(c *cli.Context) error {
+	return postfreely.UnpackTemplates()
+}

--- a/templates.go
+++ b/templates.go
@@ -11,10 +11,12 @@
 package postfreely
 
 import (
+	"embed"
 	"errors"
 	"fmt"
 	"html/template"
 	"io"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -50,6 +52,52 @@ const (
 	templatesDir = "templates"
 	pagesDir     = "pages"
 )
+
+//go:embed templates
+var templatesFS embed.FS
+
+//go:embed pages
+var pagesFS embed.FS
+
+//go:embed static
+var staticFS embed.FS
+
+func UnpackTemplates() error {
+	return errors.Join(
+		unpackFS(templatesFS, templatesDir),
+		unpackFS(pagesFS, pagesDir),
+		unpackFS(staticFS, staticDir),
+	)
+}
+
+func unpackFS(someFS embed.FS, destPath string) error {
+	return fs.WalkDir(someFS, ".", func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return unpackTemplate(someFS, path, d)
+	})
+}
+
+func unpackTemplate(someFS embed.FS, path string, d fs.DirEntry) error {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		if path == "." {
+			return nil
+		}
+		if d.IsDir() {
+			log.Info("creating directory %s", path)
+			return os.MkdirAll(path, 0700)
+		}
+		data, err := someFS.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		log.Info("creating file      %s", path)
+		return os.WriteFile(path, data, 0600)
+	}
+	log.Info("leaving existing   %s", path)
+	return nil
+}
 
 func showUserPage(w http.ResponseWriter, name string, obj interface{}) {
 	if obj == nil {


### PR DESCRIPTION
This embeds the `templates`, `pages` and `static` directories into the binary, and adds a command to unpack them. This avoids having to build `tar` or `zip` files to distribute the software; you just need the binary generated by `go build`.

Existing files are left alone, so it's safe to re-run at a later date if local modifications have been made.